### PR TITLE
Add localization injection to EmailService

### DIFF
--- a/HandmadeByDoniApp.Services.Data/HandmadeByDoniApp.Services.Data.csproj
+++ b/HandmadeByDoniApp.Services.Data/HandmadeByDoniApp.Services.Data.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\HandmadeByDoniApp.Data\HandmadeByDoniApp.Data.csproj" />
     <ProjectReference Include="..\HandmadeByDoniApp.Servises.Data.Models\HandmadeByDoniApp.Servises.Data.Models.csproj" />
     <ProjectReference Include="..\HandmadeByDoniApp.Web.ViewModels\HandmadeByDoniApp.Web.ViewModels.csproj" />
+    <ProjectReference Include="..\Resources\Resources.csproj" />
   </ItemGroup>
 
 </Project>

--- a/HandmadeByDoniApp.Services.Data/Service/EmailService.cs
+++ b/HandmadeByDoniApp.Services.Data/Service/EmailService.cs
@@ -2,7 +2,8 @@
 using HandmadeByDoniApp.Services.Data.DataRepository;
 using HandmadeByDoniApp.Services.Data.Interfaces;
 using HandmadeByDoniApp.Web.ViewModels.User;
-using MailKit.Net.Smtp; 
+using Resources.Resources;
+using MailKit.Net.Smtp;
 using MailKit.Security;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -14,14 +15,15 @@ namespace HandmadeByDoniApp.Services.Data.Service
     public class EmailService:IEmailService
     {
         private readonly IRepository repository;
-        private ILogger<EmailService> logger;
-        //private IStringLocalizer<App>
+        private readonly ILogger<EmailService> logger;
+        private readonly IStringLocalizer<App> localizer;
 
 
-        public EmailService(IRepository repository, ILogger<EmailService> logger)
+        public EmailService(IRepository repository, ILogger<EmailService> logger, IStringLocalizer<App> localizer)
         {
             this.repository = repository;
             this.logger = logger;
+            this.localizer = localizer;
         }
 
         public async Task<bool> SendEmailAsync(string toEmail, string subject, string body)

--- a/HandmadeByDoniApp.Services.Tests/OrderServiceTests.cs
+++ b/HandmadeByDoniApp.Services.Tests/OrderServiceTests.cs
@@ -14,6 +14,8 @@ namespace HandmadeByDoniApp.Services.Tests
 #pragma warning restore CS0105 // Using directive appeared previously in this namespace
     using HandmadeByDoniApp.Services.Data.Service;
     using HandmadeByDoniApp.Services.Data.DataRepository;
+    using HandmadeByDoniApp.Services.Data.Interfaces;
+    using HandmadeByDoniApp.Data.Models;
 
     public class OrderServiceTests
     {
@@ -21,6 +23,12 @@ namespace HandmadeByDoniApp.Services.Tests
         private IRepository repository;
 
         private IOrderService orderService;
+        private class FakeEmailService : IEmailService
+        {
+            public string GetConfirmEmail(string token, ApplicationUser user) => string.Empty;
+            public string GetConfirmOrderEmail(UserOrder userOrder) => string.Empty;
+            public Task<bool> SendEmailAsync(string toEmail, string subject, string body) => Task.FromResult(true);
+        }
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -34,7 +42,7 @@ namespace HandmadeByDoniApp.Services.Tests
             contex.Database.EnsureCreated();
             SeedDatabaseOrder(contex);
 
-            this.orderService = new OrderService(this.repository);
+            this.orderService = new OrderService(this.repository, new FakeEmailService());
         }
 
         [Test]

--- a/Resources/Resources.csproj
+++ b/Resources/Resources.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- inject `IStringLocalizer<App>` via DI in `EmailService`
- reference shared `Resources` project from services
- update `Resources.csproj` to build a library
- provide a `FakeEmailService` in tests for the new constructor dependency
- mark `EmailService` logger as readonly

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68401132a90c83278188b2f81631da53