### PR TITLE
Localize email templates

### DIFF
--- a/HandmadeByDoniApp.Services.Data/Service/EmailService.cs
+++ b/HandmadeByDoniApp.Services.Data/Service/EmailService.cs
@@ -90,7 +90,7 @@ namespace HandmadeByDoniApp.Services.Data.Service
             var deliveryCompany = address.DeliveryCompany.Name;
             var paymentMethod = address.MethodPayment.Method;
             var shipmentNote = !string.IsNullOrEmpty(userOrder.ShipmentNoteNumber)
-                ? $"<p><strong>Номер на товарителница:</strong> {userOrder.ShipmentNoteNumber}</p>"
+                ? $"<p><strong>{L["ShipmentNoteNumber"]}</strong> {userOrder.ShipmentNoteNumber}</p>"
                 : string.Empty;
 
             var productsHtml = "";
@@ -104,49 +104,49 @@ namespace HandmadeByDoniApp.Services.Data.Service
             }
 
             string emailBody = $@"
-                        <!DOCTYPE html>
-                        <html lang='bg'>
-                        <head>
-                            <meta charset='UTF-8'>
-                        <title>Потвърждение на поръчка</title>
-                        </head>
-                        <body style='font-family: Arial, sans-serif; color: #333; line-height: 1.6;'>
-                        <h2 style='color: #0066cc;'>Потвърждение на Вашата поръчка</h2>
-                        <p>Здравейте, <strong>{fullName}</strong>,</p>
+                    <!DOCTYPE html>
+                    <html lang='bg'>
+                    <head>
+                        <meta charset='UTF-8'>
+                        <title>{L["ConfirmOrderEmailTitle"]}</title>
+                    </head>
+                    <body style='font-family: Arial, sans-serif; color: #333; line-height: 1.6;'>
+                        <h2 style='color: #0066cc;'>{L["ConfirmOrderEmailHeading"]}</h2>
+                        <p>{L["Greeting"]}, <strong>{fullName}</strong>,</p>
 
-                        <p>Благодарим Ви, че направихте поръчка от нашия онлайн магазин!</p>
+                        <p>{L["ThankYouForOrder"]}</p>
 
-                        <h3>📦 Детайли на поръчката</h3>
-                        <p><strong>Номер на поръчка:</strong> {userOrder.OrderId}</p>
-                        <p><strong>Дата на поръчка:</strong> {orderDate}</p>
-                        <p><strong>Обща сума:</strong> {userOrder.TotalPrice:C}</p>
-                        <p><strong>Статус:</strong> {(userOrder.IsSent ? "Изпратена" : "В процес на подготовка")}</p>
-                            {shipmentNote}
+                        <h3>{L["OrderDetailsHeading"]}</h3>
+                        <p><strong>{L["OrderNumberLabel"]}</strong> {userOrder.OrderId}</p>
+                        <p><strong>{L["OrderDateLabel"]}</strong> {orderDate}</p>
+                        <p><strong>{L["TotalPriceLabel"]}</strong> {userOrder.TotalPrice:C}</p>
+                        <p><strong>{L["Status"]}</strong> {(userOrder.IsSent ? L["OrderSent"] : L["OrderPreparing"])}</p>
+                        {shipmentNote}
 
-                        <h3>🛒 Закупени продукти</h3>
-                            <table style='width: 100%; border-collapse: collapse;'>
-                                <thead>
-                                    <tr>
-                                    <th style='padding: 8px; border: 1px solid #ccc; background-color: #f2f2f2;'>Продукт</th>
-                                    <th style='padding: 8px; border: 1px solid #ccc; background-color: #f2f2f2;'>Цена</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {productsHtml}
-                                </tbody>
-                            </table>
+                        <h3>{L["PurchasedProductsHeading"]}</h3>
+                        <table style='width: 100%; border-collapse: collapse;'>
+                            <thead>
+                                <tr>
+                                    <th style='padding: 8px; border: 1px solid #ccc; background-color: #f2f2f2;'>{L["Product"]}</th>
+                                    <th style='padding: 8px; border: 1px solid #ccc; background-color: #f2f2f2;'>{L["Price"]}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {productsHtml}
+                            </tbody>
+                        </table>
 
-                        <h3>🚚 Данни за доставка</h3>
-                        <p><strong>Адрес:</strong> {address.Street}, {address.CityName}, {address.CountryName}</p>
-                        <p><strong>Телефон за контакт:</strong> {address.PhoneNumber}</p>
-                        <p><strong>Куриер:</strong> {deliveryCompany}</p>
-                        <p><strong>Метод на плащане:</strong> {paymentMethod}</p>
+                        <h3>{L["DeliveryDetailsHeading"]}</h3>
+                        <p><strong>{L["Address"]}</strong> {address.Street}, {address.CityName}, {address.CountryName}</p>
+                        <p><strong>{L["ContactPhone"]}</strong> {address.PhoneNumber}</p>
+                        <p><strong>{L["Courier"]}</strong> {deliveryCompany}</p>
+                        <p><strong>{L["MethodPayment"]}</strong> {paymentMethod}</p>
 
-                            <br>
-                        <p>Ако имате въпроси, не се колебайте да се свържете с нас!</p>
+                        <br>
+                        <p>{L["QuestionsContactUs"]}</p>
 
-                        <p>С уважение,<br><strong>Екипът на HandmadeByDoni</strong></p>
-                        </body>
+                        <p>{L["Regards"]},<br><strong>{L["HandmadeByDoniTeam"]}</strong></p>
+                    </body>
                     </html>
 ";
 
@@ -166,22 +166,22 @@ namespace HandmadeByDoniApp.Services.Data.Service
                             <html lang='bg'>
                             <head>
                                 <meta charset='UTF-8'>
-                                    <title>Потвърждение на имейл</title>
+                                    <title>{L["ConfirmEmailTitle"]}</title>
                             </head>
                             <body style='font-family: Arial, sans-serif; color: #333; line-height: 1.6;'>
-                                    <h2 style='color: #0066cc;'>Добре дошли, {user.FirstName}!</h2>
-                                    <p>Благодарим Ви, че се регистрирахте в нашата платформа.</p>
+                                    <h2 style='color: #0066cc;'>{string.Format(L["WelcomeUser"], user.FirstName)}</h2>
+                                    <p>{L["ThankYouForRegistering"]}</p>
 
-                                    <p>Моля, потвърдете Вашия имейл адрес, като кликнете на бутона по-долу:</p>
+                                    <p>{L["PleaseConfirmEmail"]}</p>
 
                                 <p style='margin: 30px 0;'>
                                     <a href='{confirmationLink}' style='padding: 10px 20px; background-color: #28a745; color: #fff;
-                                        text-decoration: none; border-radius: 5px;'>Потвърди имейл</a>
+                                        text-decoration: none; border-radius: 5px;'>{L["ConfirmEmailButton"]}</a>
                                 </p>
 
-                                    <p>Ако не сте се регистрирали при нас, игнорирайте този имейл.</p>
+                                    <p>{L["IgnoreIfNotRegistered"]}</p>
 
-                                    <p>С уважение,<br><strong>Екипът на HandmadeByDoni</strong></p>
+                                    <p>{L["Regards"]},<br><strong>{L["HandmadeByDoniTeam"]}</strong></p>
                             </body>
                                 </html>
                                 ";

--- a/Resources/Resources/App.bg-BG.resx
+++ b/Resources/Resources/App.bg-BG.resx
@@ -585,4 +585,73 @@
   <data name="ЕmailSendError" xml:space="preserve">
     <value />
   </data>
+  <data name="ConfirmOrderEmailTitle" xml:space="preserve">
+    <value>Потвърждение на поръчка</value>
+  </data>
+  <data name="ConfirmOrderEmailHeading" xml:space="preserve">
+    <value>Потвърждение на Вашата поръчка</value>
+  </data>
+  <data name="Greeting" xml:space="preserve">
+    <value>Здравейте</value>
+  </data>
+  <data name="ThankYouForOrder" xml:space="preserve">
+    <value>Благодарим Ви, че направихте поръчка от нашия онлайн магазин!</value>
+  </data>
+  <data name="OrderDetailsHeading" xml:space="preserve">
+    <value>Детайли на поръчката</value>
+  </data>
+  <data name="OrderNumberLabel" xml:space="preserve">
+    <value>Номер на поръчка:</value>
+  </data>
+  <data name="OrderDateLabel" xml:space="preserve">
+    <value>Дата на поръчка:</value>
+  </data>
+  <data name="TotalPriceLabel" xml:space="preserve">
+    <value>Обща сума:</value>
+  </data>
+  <data name="OrderSent" xml:space="preserve">
+    <value>Изпратена</value>
+  </data>
+  <data name="OrderPreparing" xml:space="preserve">
+    <value>В процес на подготовка</value>
+  </data>
+  <data name="PurchasedProductsHeading" xml:space="preserve">
+    <value>Закупени продукти</value>
+  </data>
+  <data name="DeliveryDetailsHeading" xml:space="preserve">
+    <value>Данни за доставка</value>
+  </data>
+  <data name="ContactPhone" xml:space="preserve">
+    <value>Телефон за контакт:</value>
+  </data>
+  <data name="Courier" xml:space="preserve">
+    <value>Куриер:</value>
+  </data>
+  <data name="QuestionsContactUs" xml:space="preserve">
+    <value>Ако имате въпроси, не се колебайте да се свържете с нас!</value>
+  </data>
+  <data name="Regards" xml:space="preserve">
+    <value>С уважение</value>
+  </data>
+  <data name="HandmadeByDoniTeam" xml:space="preserve">
+    <value>Екипът на HandmadeByDoni</value>
+  </data>
+  <data name="ConfirmEmailTitle" xml:space="preserve">
+    <value>Потвърждение на имейл</value>
+  </data>
+  <data name="WelcomeUser" xml:space="preserve">
+    <value>Добре дошли, {0}!</value>
+  </data>
+  <data name="ThankYouForRegistering" xml:space="preserve">
+    <value>Благодарим Ви, че се регистрирахте в нашата платформа.</value>
+  </data>
+  <data name="PleaseConfirmEmail" xml:space="preserve">
+    <value>Моля, потвърдете Вашия имейл адрес, като кликнете на бутона по-долу:</value>
+  </data>
+  <data name="ConfirmEmailButton" xml:space="preserve">
+    <value>Потвърди имейл</value>
+  </data>
+  <data name="IgnoreIfNotRegistered" xml:space="preserve">
+    <value>Ако не сте се регистрирали при нас, игнорирайте този имейл.</value>
+  </data>
 </root>

--- a/Resources/Resources/App.en-US.resx
+++ b/Resources/Resources/App.en-US.resx
@@ -576,4 +576,73 @@
   <data name="OrderFrom" xml:space="preserve">
     <value>Order from {0}</value>
   </data>
+  <data name="ConfirmOrderEmailTitle" xml:space="preserve">
+    <value>Order Confirmation</value>
+  </data>
+  <data name="ConfirmOrderEmailHeading" xml:space="preserve">
+    <value>Your order confirmation</value>
+  </data>
+  <data name="Greeting" xml:space="preserve">
+    <value>Hello</value>
+  </data>
+  <data name="ThankYouForOrder" xml:space="preserve">
+    <value>Thank you for shopping with us!</value>
+  </data>
+  <data name="OrderDetailsHeading" xml:space="preserve">
+    <value>Order details</value>
+  </data>
+  <data name="OrderNumberLabel" xml:space="preserve">
+    <value>Order number:</value>
+  </data>
+  <data name="OrderDateLabel" xml:space="preserve">
+    <value>Order date:</value>
+  </data>
+  <data name="TotalPriceLabel" xml:space="preserve">
+    <value>Total amount:</value>
+  </data>
+  <data name="OrderSent" xml:space="preserve">
+    <value>Sent</value>
+  </data>
+  <data name="OrderPreparing" xml:space="preserve">
+    <value>In preparation</value>
+  </data>
+  <data name="PurchasedProductsHeading" xml:space="preserve">
+    <value>Purchased products</value>
+  </data>
+  <data name="DeliveryDetailsHeading" xml:space="preserve">
+    <value>Delivery details</value>
+  </data>
+  <data name="ContactPhone" xml:space="preserve">
+    <value>Contact phone:</value>
+  </data>
+  <data name="Courier" xml:space="preserve">
+    <value>Courier:</value>
+  </data>
+  <data name="QuestionsContactUs" xml:space="preserve">
+    <value>If you have any questions, do not hesitate to contact us!</value>
+  </data>
+  <data name="Regards" xml:space="preserve">
+    <value>Best regards</value>
+  </data>
+  <data name="HandmadeByDoniTeam" xml:space="preserve">
+    <value>HandmadeByDoni Team</value>
+  </data>
+  <data name="ConfirmEmailTitle" xml:space="preserve">
+    <value>Email confirmation</value>
+  </data>
+  <data name="WelcomeUser" xml:space="preserve">
+    <value>Welcome, {0}!</value>
+  </data>
+  <data name="ThankYouForRegistering" xml:space="preserve">
+    <value>Thank you for registering on our platform.</value>
+  </data>
+  <data name="PleaseConfirmEmail" xml:space="preserve">
+    <value>Please confirm your email by clicking the button below:</value>
+  </data>
+  <data name="ConfirmEmailButton" xml:space="preserve">
+    <value>Confirm Email</value>
+  </data>
+  <data name="IgnoreIfNotRegistered" xml:space="preserve">
+    <value>If you did not register with us, please ignore this email.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- localize email body strings using resource keys
- add English and Bulgarian translations
- fix missing newline at end of resource files

## Testing
- `dotnet test HandmadeByDoniApp.Services.Tests/HandmadeByDoniApp.Services.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412fd8f5488327959c1a719ccf01e3